### PR TITLE
Fix for django bit-sets blowing up due to TypePredicate New-Release c…

### DIFF
--- a/refactor/query_testing_back_end/django/defaults.py
+++ b/refactor/query_testing_back_end/django/defaults.py
@@ -16,7 +16,7 @@ class DjangoDefaultHandler(DefaultHandler):
     @staticmethod
     def get_default_decision_tree_builder(language, prediction_goal) -> TreeBuilder:
         tilde_config = TildeConfig.get_instance()
-        test_evaluator = DjangoQueryEvaluator()
+        test_evaluator = DjangoQueryEvaluator(language, prediction_goal)
         test_generator_builder = FOLTestGeneratorBuilder(language=language,
                                                             query_head_if_keys_format=prediction_goal)
 

--- a/refactor/query_testing_back_end/django/evaluation.py
+++ b/refactor/query_testing_back_end/django/evaluation.py
@@ -1,4 +1,7 @@
+from problog.logic import Term
+
 from refactor.tilde_essentials.evaluation import TestEvaluator
+from refactor.representation.language import TypeModeLanguage
 from refactor.query_testing_back_end.django.django_example import DjangoExample
 try:
     from src.ClauseWrapper import ClauseWrapper, HypothesisWrapper
@@ -12,6 +15,17 @@ from refactor.query_testing_back_end.django.clause_handling import build_hypothe
 
 
 class DjangoQueryEvaluator(TestEvaluator):
+    def __init__(self, language: TypeModeLanguage, prediction_goal: Term):
+        super().__init__()
+        # This is to prevent django from blowing up bit-sets  NewTypePredicate-ReleaseTypePredicate cycles.
+        # tl;dr : We create a clause with all possible predicates AND DO NOT DELETE IT till the end of the program.
+        # This ensures a reference count of one and prevents django from growing the bitset each time.
+        self.reference_pin_clause = ClauseWrapper(clause_id=None)
+        self.reference_pin_clause.add_literal_as_head(Term(prediction_goal.functor, ["__refpin_arg__"] * prediction_goal.arity) ) # Ok, how do i do that?
+        for rmode in language.get_refinement_modes():
+            self.reference_pin_clause.add_literal_to_body(Term(rmode[0], ["__refpin_arg__"] * rmode[1]))
+        self.reference_pin_clause.lock_adding_to_clause()
+
     def evaluate(self, example: DjangoExample, test: HypothesisWrapper) -> bool:
         example_clause_wrapper = example.external_representation  # type: ClauseWrapper
         does_subsume, run_time_ms = check_subsumption(test, example_clause_wrapper)


### PR DESCRIPTION
Fix for django blowing up it's BitSet due to NewTypePredicate, ReleaseTypePredicate cycles.
If a refcount reaches 0 on ReleaseTypePredicate, django forgets it has ever seen that predicate. A subsequent NewTypePredicate will be treated as a new one and grow the Bitset, quickly leading to very large bitsets and very bad performance.
The fix is to pin one instance of each predicate in a clause for the entire duration of execution. 